### PR TITLE
Fix the path to get zero-epwing

### DIFF
--- a/epwing.go
+++ b/epwing.go
@@ -78,9 +78,9 @@ func epwingExportDb(inputPath, outputPath, language, title string, stride int, p
 
 	var data []byte
 	if toolExec {
-		ex, err := os.Executable()
+		exePath, err := os.Executable()
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		toolPath := filepath.Join("bin", runtime.GOOS, "zero-epwing")
@@ -88,7 +88,7 @@ func epwingExportDb(inputPath, outputPath, language, title string, stride int, p
 			toolPath += ".exe"
 		}
 
-		toolPath = filepath.Join(filepath.Dir(ex), toolPath)
+		toolPath = filepath.Join(filepath.Dir(exePath), toolPath)
 
 		if _, err = os.Stat(toolPath); err != nil {
 			return fmt.Errorf("failed to find zero-epwing in '%s'", toolPath)

--- a/epwing.go
+++ b/epwing.go
@@ -78,14 +78,17 @@ func epwingExportDb(inputPath, outputPath, language, title string, stride int, p
 
 	var data []byte
 	if toolExec {
+		ex, err := os.Executable()
+		if err != nil {
+			panic(err)
+		}
+
 		toolPath := filepath.Join("bin", runtime.GOOS, "zero-epwing")
 		if runtime.GOOS == "windows" {
 			toolPath += ".exe"
 		}
 
-		if toolPath, err = filepath.Abs(toolPath); err != nil {
-			return err
-		}
+		toolPath = filepath.Join(filepath.Dir(ex), toolPath)
 
 		if _, err = os.Stat(toolPath); err != nil {
 			return fmt.Errorf("failed to find zero-epwing in '%s'", toolPath)


### PR DESCRIPTION
When running on macOS 10.15, it goes to the wrong path to find zero-epwing.

<img width="480" alt="issue-path" src="https://user-images.githubusercontent.com/26762575/75088592-71b8b680-558a-11ea-8b2b-93bbbec04684.png">

As shown, it tries to find on `~/bin/darwin/` while the yomichan-import program is at
```
$ pwd 
/Users/playhing/Documents/self/project/anki/yomichan-import
```
The issue was fixed according to [this](https://stackoverflow.com/a/18537419).