### PR TITLE
Add winmanifest import

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/andlabs/ui"
+	_ "github.com/andlabs/ui/winmanifest"
 )
 
 type logger struct {


### PR DESCRIPTION
I am admittedly not that familiar with golang, but building using the most recent MinGW64 + Go tools gave the following error:
```
The procedure entry point TaskDialog could not be located in the dynamic link library.
```

This appears to be fixed by adding an additional import, see: https://github.com/andlabs/ui/blob/master/README.md#windows-manifests